### PR TITLE
CRUD operations for tasks

### DIFF
--- a/src/crud.js
+++ b/src/crud.js
@@ -1,0 +1,39 @@
+// Complete button listener
+export const completeTaskListener = (task) => (event) => {
+  event.preventDefault();
+  task.toggleCompleted();
+  const li = event.target.closest('li');
+  task.render(li);
+};
+
+// Description listener
+export const descriptionListener = (task) => (event) => {
+  event.preventDefault();
+  const li = event.target.closest('li');
+  task.render(li, true).focus();
+};
+
+// Task input listener
+export const taskUpdateListener = (task) => (event) => {
+  event.preventDefault();
+  const description = event.target.getElementsByTagName('input')[0].value;
+  const li = event.target.closest('li');
+  task.updateDesctiption(description);
+  task.render(li);
+};
+
+// Add task listener
+export const addTaskListener = (list, container) => (event) => {
+  event.preventDefault();
+  const input = event.target.getElementsByTagName('input')[0];
+  list.addTask(input.value);
+  input.value = '';
+  list.render(container);
+};
+
+// Delete completed tasks listener
+export const clearCompletedListener = (list, container) => (event) => {
+  event.preventDefault();
+  list.deleteCompleted();
+  list.render(container);
+};

--- a/src/crud.js
+++ b/src/crud.js
@@ -1,9 +1,17 @@
+const saveItems = {};
+
+export const saveList = (list = false) => {
+  if (list) saveItems.list = list;
+  if (saveItems.list) saveItems.list.save();
+};
+
 // Complete button listener
 export const completeTaskListener = (task) => (event) => {
   event.preventDefault();
   task.toggleCompleted();
   const li = event.target.closest('li');
   task.render(li);
+  saveList();
 };
 
 // Description listener
@@ -19,6 +27,7 @@ export const taskUpdateListener = (task) => (event) => {
   const description = event.target.getElementsByTagName('input')[0].value;
   const li = event.target.closest('li');
   task.updateDesctiption(description);
+  saveList();
   task.render(li);
 };
 
@@ -29,11 +38,13 @@ export const addTaskListener = (list, container) => (event) => {
   list.addTask(input.value);
   input.value = '';
   list.render(container);
+  saveList();
 };
 
 // Delete completed tasks listener
 export const clearCompletedListener = (list, container) => (event) => {
   event.preventDefault();
   list.deleteCompleted();
+  saveList();
   list.render(container);
 };

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
         </form>
         <ul id="to-do-list">
         </ul>
-        <button class="clear-completed">Clear all completed</button>
+        <button id="clear-completed">Clear all completed</button>
     </div>
 </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 import './style.css';
 import 'font-awesome/css/font-awesome.css';
 import ToDoList from './toDoList';
-import { addTaskListener, clearCompletedListener } from './crud';
+import { addTaskListener, clearCompletedListener, saveList } from './crud';
 
 const toDoUl = document.getElementById('to-do-list');
 
 const toDoList = new ToDoList();
+saveList(toDoList);
 
 const newTaskForm = document.getElementById('new-task');
 newTaskForm.addEventListener('submit', addTaskListener(toDoList, toDoUl));

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,20 @@
 import './style.css';
 import 'font-awesome/css/font-awesome.css';
-import Task from './task';
 import ToDoList from './toDoList';
+import { addTaskListener, clearCompletedListener } from './crud';
 
 const toDoUl = document.getElementById('to-do-list');
 
-const toDoList = new ToDoList([
-  new Task('Bathe the dog', 1, false),
-  new Task('Fix the sink', 3, false),
-  new Task('Feed the kitty cat', 2, true),
-]);
+const toDoList = new ToDoList();
+
+const newTaskForm = document.getElementById('new-task');
+newTaskForm.addEventListener('submit', addTaskListener(toDoList, toDoUl));
+
+const clearCompletedButton = document.getElementById('clear-completed');
+clearCompletedButton.addEventListener('click', clearCompletedListener(toDoList, toDoUl));
 
 toDoList.render(toDoUl);
+
+window.addEventListener('unload', () => {
+  toDoList.save();
+});

--- a/src/style.css
+++ b/src/style.css
@@ -85,8 +85,8 @@ button:hover {
   text-decoration: underline;
 }
 
-#new-item,
-#new-item:focus {
+input[type=text],
+input[type=text]:focus {
   border: none;
   outline: none;
   font-family: inherit;

--- a/src/style.css
+++ b/src/style.css
@@ -69,7 +69,7 @@ button:hover {
   color: black;
 }
 
-.clear-completed {
+#clear-completed {
   display: block;
   margin: auto;
   height: 55px;

--- a/src/task.js
+++ b/src/task.js
@@ -5,39 +5,64 @@ export default class Task {
     this.completed = completed;
   }
 
-  render() {
-    const taskContainer = document.createElement('li');
-    taskContainer.classList.add('to-do-task');
-    taskContainer.classList.add('app-entry');
-
-    const taskLeft = document.createElement('div');
-    const taskCompleteButton = document.createElement('button');
-
-    const taskDescription = document.createElement('p');
-    taskDescription.classList.add('task-description');
-    taskDescription.innerHTML = this.description;
-
+  renderCompleteButton() {
+    const completeButton = document.createElement('button');
     if (this.completed) {
-      taskCompleteButton.innerHTML = '<i class="fa fa-check" aria-hidden="true"></i>';
-      taskDescription.classList.add('completed-task');
-      taskCompleteButton.classList.add('checked-task');
+      completeButton.innerHTML = '<i class="fa fa-check" aria-hidden="true"></i>';
+      completeButton.classList.add('checked-task');
     } else {
-      taskCompleteButton.innerHTML = '<i class="fa fa-square-o" aria-hidden="true"></i>';
+      completeButton.innerHTML = '<i class="fa fa-square-o" aria-hidden="true"></i>';
     }
+    return completeButton;
+  }
 
-    const taskDrag = document.createElement('p');
-    taskDrag.innerHTML = '<i class="fa fa-ellipsis-v" aria-hidden="true"></i>';
-    taskDrag.classList.add('gray-icon');
+  renderDescriptionP() {
+    const descriptionP = document.createElement('p');
+    descriptionP.classList.add('task-description');
+    descriptionP.innerHTML = this.description;
+    if (this.completed) descriptionP.classList.add('completed-task');
 
-    taskLeft.appendChild(taskCompleteButton);
-    taskLeft.appendChild(taskDescription);
-    taskContainer.appendChild(taskLeft);
-    taskContainer.appendChild(taskDrag);
+    return descriptionP;
+  }
 
-    return { html: taskContainer, button: taskCompleteButton, drag: taskDrag };
+  renderDescriptionInput() {
+    const descriptionInput = document.createElement('input');
+    descriptionInput.classList.add('task-description');
+    descriptionInput.type = 'text';
+    descriptionInput.placeholder = this.description;
+
+    return descriptionInput;
+  }
+
+  render(withInput) {
+    const container = document.createElement('li');
+    container.classList.add('to-do-task');
+    container.classList.add('app-entry');
+    const containerLeft = document.createElement('div');
+
+    const button = this.renderCompleteButton();
+    const description = withInput ? this.renderDescriptionInput()
+      : this.renderDescriptionP();
+    const drag = document.createElement('p');
+    drag.innerHTML = '<i class="fa fa-ellipsis-v" aria-hidden="true"></i>';
+    drag.classList.add('gray-icon');
+
+    containerLeft.append(button, description);
+    container.append(containerLeft, drag);
+
+    return {
+      html: container,
+      button,
+      description,
+      drag,
+    };
   }
 
   toggleCompleted() {
     this.completed = !this.completed;
+  }
+
+  updateDesctiption(newDescription) {
+    this.description = newDescription;
   }
 }

--- a/src/task.js
+++ b/src/task.js
@@ -1,3 +1,9 @@
+import {
+  completeTaskListener,
+  descriptionListener,
+  taskUpdateListener,
+} from './crud';
+
 export default class Task {
   constructor(description, index, completed = false) {
     this.description = description;
@@ -13,6 +19,9 @@ export default class Task {
     } else {
       completeButton.innerHTML = '<i class="fa fa-square-o" aria-hidden="true"></i>';
     }
+
+    completeButton.addEventListener('click', completeTaskListener(this));
+
     return completeButton;
   }
 
@@ -22,20 +31,25 @@ export default class Task {
     descriptionP.innerHTML = this.description;
     if (this.completed) descriptionP.classList.add('completed-task');
 
+    descriptionP.addEventListener('click', descriptionListener(this));
+
     return descriptionP;
   }
 
   renderDescriptionInput() {
+    const form = document.createElement('form');
+    form.classList.add('task-description');
     const descriptionInput = document.createElement('input');
-    descriptionInput.classList.add('task-description');
     descriptionInput.type = 'text';
     descriptionInput.placeholder = this.description;
+    form.appendChild(descriptionInput);
+    form.addEventListener('submit', taskUpdateListener(this));
 
-    return descriptionInput;
+    return form;
   }
 
-  render(withInput) {
-    const container = document.createElement('li');
+  render(container, withInput = false) {
+    container.innerHTML = '';
     container.classList.add('to-do-task');
     container.classList.add('app-entry');
     const containerLeft = document.createElement('div');
@@ -43,19 +57,13 @@ export default class Task {
     const button = this.renderCompleteButton();
     const description = withInput ? this.renderDescriptionInput()
       : this.renderDescriptionP();
+    containerLeft.append(button, description);
+
     const drag = document.createElement('p');
     drag.innerHTML = '<i class="fa fa-ellipsis-v" aria-hidden="true"></i>';
     drag.classList.add('gray-icon');
-
-    containerLeft.append(button, description);
     container.append(containerLeft, drag);
-
-    return {
-      html: container,
-      button,
-      description,
-      drag,
-    };
+    return description;
   }
 
   toggleCompleted() {

--- a/src/toDoList.js
+++ b/src/toDoList.js
@@ -1,12 +1,12 @@
 import Task from './task';
 
 export default class ToDoList {
-  constructor(tasks = []) {
+  constructor() {
     const lsList = JSON.parse(localStorage.getItem('ToDoList'));
     if (lsList) {
       this.list = lsList.map((task) => new Task(task.description, task.index, task.completed));
     } else {
-      this.list = tasks;
+      this.list = [];
     }
   }
 
@@ -18,14 +18,22 @@ export default class ToDoList {
     container.innerHTML = '';
     this.list.sort((task1, task2) => task1.index - task2.index)
       .forEach((task) => {
-        const { html, button } = task.render();
-        button.addEventListener('click', (event) => {
-          event.preventDefault();
-          task.toggleCompleted();
-          this.save();
-          this.render(container);
-        });
-        container.appendChild(html);
+        const li = document.createElement('li');
+        task.render(li);
+        container.appendChild(li);
       });
+  }
+
+  addTask(description) {
+    const index = this.list.length;
+    const task = new Task(description, index);
+    this.list.push(task);
+  }
+
+  deleteCompleted() {
+    this.list = this.list.filter((task) => !task.completed);
+    this.list.forEach((task, index) => {
+      task.index = index;
+    });
   }
 }


### PR DESCRIPTION
In this pull request, the following features are to be implemented:
- [x] Add support to add tasks and clear completed tasks to `ToDoList` class.
- [x] Add support to update tasks descriptions to `Task` class.
- [x] Add code to render a form for updating tasks descriptions.
- [x] Create functions to build event listeners for:
  - [x] New task form.
  - [x] Clear completed tasks button.
  - [x] Update tasks form.
- [x] Add the event listeners to their respective elements.
- [x] Set `window` unload listener to save the list to `localStorage` before leaving the page. 

Requested changes:
- [x] Add a trigger to save the list to `localStorage` whenever it's updated.